### PR TITLE
Bug/transitiondensitywindow

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The following shortcuts can be used to navigate the different windows, also foun
 Only works if a Hidden Markov Model has been fit to the traces
 - Set the number of clusters (transitions) per half of the TDP plot to extract lifetimes for each transition. 
 The number of clusters per half is typically equal to the number of states.
-- N.B. In order to see wider distributions, change the Preferences to Idealize traces individually. (requires restart)
+- N.B. In order to see wider distributions, change the Preferences to Idealize traces individually. (will only apply to new traces, so might require restart.)
 
 ## Trace Simulator Window
 - Choose the parameters with which to simulate traces and press the `Refresh` button. 

--- a/src/main/python/widgets/trace_window.py
+++ b/src/main/python/widgets/trace_window.py
@@ -331,8 +331,7 @@ class TraceWindow(BaseWindow):
 
             trace.calculate_transitions()
 
-        if self.windows["TransitionDensityWindow"].isVisible():
-            self.windows["TransitionDensityWindow"].refreshPlot()
+        self.windows["TransitionDensityWindow"].refreshPlot()
 
     @staticmethod
     def setClassifications(trace, yi_pred):

--- a/src/main/python/widgets/transition_density_window.py
+++ b/src/main/python/widgets/transition_density_window.py
@@ -144,7 +144,7 @@ class TransitionDensityWindow(BaseWindow):
                 {
                     "e_before": self.data.tdpData.state_before,
                     "e_after": self.data.tdpData.state_after,
-                    "lifetime": self.data.tdpData.state_after,
+                    "lifetime": self.data.tdpData.state_lifetime,
                 }
             )
 
@@ -312,6 +312,7 @@ class TransitionDensityWindow(BaseWindow):
                     bins=bins,
                     color=self.colors[k],
                     density=False,
+                    label="N: {}".format(len(cluster)),
                 )
                 self.hist_axes[k].set_xlim(0, max(bins))
                 self.hist_axes[k].set_ylim(0, max(histy) * 1.1)


### PR DESCRIPTION
Fixes #6 .
- Forces update of TransitionDensityWindow plot regardless of visibility at the end of `TraceWindow.fitCheckedTracesHiddenMarkovModel()` call.
- Fixes wrong assignment of lifetime where lifetimes are assigned to `tdpData.state_after`.