### PR TITLE
correct framerate calculation

### DIFF
--- a/src/main/python/lib/container.py
+++ b/src/main/python/lib/container.py
@@ -391,7 +391,7 @@ class TraceContainer:
         self.acc.bg = zeros
         self.red.bg = zeros * np.nan
 
-        self.framerate = int(1 / (arr[0, 1] - arr[0, 0]))
+        self.framerate = int(1 / (arr[1, 0] - arr[0, 0]))
 
         self.calculate_fret()
         self.calculate_stoi()


### PR DESCRIPTION
Hi! 

While trying to load my own traces in DeepFRET in plain text dat files I think I've stumbled on a bug.

If dat files count on the first column being time, then I think the frame rate was calculated wrongly before; it should take the first two values out of the first column instead of the first two values of the first row.